### PR TITLE
Add zoned date time generic impl

### DIFF
--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -1,2 +1,3 @@
 setuptools>=62.0
+tzdata>=2023.3
 pytest

--- a/src/main/java/com/regnosys/rosetta/generator/python/expressions/PythonExpressionGenerator.xtend
+++ b/src/main/java/com/regnosys/rosetta/generator/python/expressions/PythonExpressionGenerator.xtend
@@ -96,7 +96,7 @@ class PythonExpressionGenerator {
             ToDateTimeOperation: '''datetime.datetime.strptime(«generateExpression(expr.argument, ifLevel, isLambda)», "%Y-%m-%d %H:%M:%S")'''
             ToIntOperation: '''int(«generateExpression(expr.argument, ifLevel, isLambda)»)'''
             ToTimeOperation: '''datetime.datetime.strptime(«generateExpression(expr.argument, ifLevel, isLambda)», "%H:%M:%S").time()'''
-            ToZonedDateTimeOperation:'''datetime.datetime.strptime(«generateExpression(expr.argument, ifLevel, isLambda)», "%Y-%m-%d %H:%M:%S %z %Z")'''
+            ToZonedDateTimeOperation:'''rune_zoned_date_time(«generateExpression(expr.argument, ifLevel, isLambda)»)'''
             // Rune Operations
             RosettaAbsentExpression: '''(not rune_attr_exists(«generateExpression(expr.argument, ifLevel, isLambda)»))'''
             RosettaBinaryOperation: generateBinaryExpression(expr, ifLevel, isLambda)

--- a/test/python_unit_tests/semantics/test_to_zoned_date_time.py
+++ b/test/python_unit_tests/semantics/test_to_zoned_date_time.py
@@ -1,20 +1,42 @@
 '''to-zoned-date-time unit tests'''
-
 import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from rosetta_dsl.test.semantic.toZonedDateTimeOp.TestToZonedDateTimeOp import TestToZonedDateTimeOp
 
-def test_to_zoned_date_time_passes(): 
-    to_zoned_date_time_test= TestToZonedDateTimeOp(a="2025-05-26 14:30:00 +0900 UTC",b=datetime.datetime(2025, 5, 26, 14, 30, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=9), 'UTC')))
+
+def test_to_zoned_date_time_offset_and_time_zone():
+    to_zoned_date_time_test= TestToZonedDateTimeOp(a="2025-07-07 15:30:00 +0100 Europe/Lisbon",b=datetime.datetime(2025,7, 7, 15, 30, 0, tzinfo=ZoneInfo("Europe/Lisbon")))
+    to_zoned_date_time_test.validate_model()
+    
+def test_to_zoned_date_time_only_time_zone():
+    to_zoned_date_time_test= TestToZonedDateTimeOp(a="2025-07-07 15:30:00 Europe/Lisbon",b=datetime.datetime(2025,7, 7, 15, 30, 0, tzinfo=ZoneInfo("Europe/Lisbon")))
     to_zoned_date_time_test.validate_model()
 
+def test_to_zoned_date_time_only_time_zone2():
+    to_zoned_date_time_test= TestToZonedDateTimeOp(a="2025-03-15 12:00:00 Zulu",b=datetime.datetime(2025,3, 15, 12, 0, 0, tzinfo=ZoneInfo("Zulu")))
+    to_zoned_date_time_test.validate_model()
+
+def test_to_zoned_date_time_only_offset():
+    to_zoned_date_time_test= TestToZonedDateTimeOp(a="2025-05-26 14:30:00 +0900",b=datetime.datetime(2025,5, 26, 14, 30, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=9))))
+    to_zoned_date_time_test.validate_model()
+    
 def test_to_zoned_date_time_fails():
-    to_zoned_date_time_test= TestToZonedDateTimeOp(a="2025-05-26 14:30:00 +09x0 UTC",b=datetime.datetime(2025, 5, 26, 14, 30, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=9), 'UTC')))
+    to_zoned_date_time_test= TestToZonedDateTimeOp(a="2025-12-15 15:30:00 +0100 Europe/Lisbon",b=datetime.datetime(2025, 5, 26, 14, 30, 0, tzinfo=ZoneInfo("Europe/Lisbon")))
+    with pytest.raises(Exception):
+        to_zoned_date_time_test.validate_model()
+
+def test_to_zoned_date_time_fails_format():
+    to_zoned_date_time_test= TestToZonedDateTimeOp(a="2025-05-26 14:30:00 +09x0",b=datetime.datetime(2025, 5, 26, 14, 30, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=9))))
     with pytest.raises(Exception):
         to_zoned_date_time_test.validate_model()
         
 if __name__ == "__main__":
-    test_to_zoned_date_time_passes()
+    test_to_zoned_date_time_offset_and_time_zone()
+    test_to_zoned_date_time_only_time_zone()
+    test_to_zoned_date_time_only_time_zone2()
+    test_to_zoned_date_time_only_offset()
     test_to_zoned_date_time_fails()
+    test_to_zoned_date_time_fails_format()


### PR DESCRIPTION
During the implementation of the [issue ](https://github.com/finos/rune-python-generator/issues/11), an opportunity to generalize the to-zoned-date-time operator was identified. The goal of this generalization is to allow a wider range of input strings to be parsed into a zoned date-time object. This new implementation works with a runtime function (`rune_zoned_date_time`) and includes tests for the variety of string formats that can be used as an input to create a zoned-datetime object. To work with time zones, the Python library used to interpret them required the `tzdata`>=2023.3 dependency.